### PR TITLE
fix: :bug: fix the application looking for core centroids when not in…

### DIFF
--- a/app.py
+++ b/app.py
@@ -413,7 +413,7 @@ if tma_mode:
         for coordinate_pair in core_centroids
     ]
 
-core_centroids = np.array(core_centroids)
+    core_centroids = np.array(core_centroids)
 
 
 # PROCESSING QUANTIFICATION DATA


### PR DESCRIPTION
… tma mode

The application no longer tries (and fails) to read core centroids when there is no TMA data present